### PR TITLE
move BitSet out of global dict to each object

### DIFF
--- a/src/ProtoBuf.jl
+++ b/src/ProtoBuf.jl
@@ -12,7 +12,7 @@ export ProtoServiceException, ProtoRpcChannel, ProtoRpcController, MethodDescrip
        find_method, get_request_type, get_response_type, get_descriptor_for_type, call_method
 
 fld_type(o::T, fld) where {T} = fieldtype(T, fld)
-fld_names(x) = x.name.names
+fld_names(x) = [name for name in x.name.names if name !== :__fill_cache]
 
 include("codec.jl")
 include("svc.jl")

--- a/src/codec.jl
+++ b/src/codec.jl
@@ -484,6 +484,7 @@ end
 
 function readproto(io::IO, obj, meta::ProtoMeta=meta(typeof(obj)))
     @debug("readproto begin: $(typeof(obj))")
+    # println("readproto obj=$obj")
     fillunset(obj)
     fldnums = collect(keys(meta.numdict))
     while !eof(io)

--- a/src/gen.jl
+++ b/src/gen.jl
@@ -463,6 +463,7 @@ function generate_msgtype(outio::IO, errio::IO, dtype::DescriptorProto, scope::S
             end
         end
     end
+    println(io, "    __fill_cache::Union{Nothing,BitArray{2}}") # TODO: just BitArray{2}
     println(io, "    $(dtypename)(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)")
     println(io, "end #mutable struct $(dtypename)", ismapentry ? " (mapentry)" : "", deferedmode ? " (has cyclic type dependency)" : "")
 

--- a/src/google/any_pb.jl
+++ b/src/google/any_pb.jl
@@ -5,6 +5,7 @@ import ProtoBuf.meta
 mutable struct _Any <: ProtoType
     type_url::AbstractString
     value::Array{UInt8,1}
+    __fill_cache::Union{Nothing,BitArray{2}}
     _Any(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct _Any
 

--- a/src/google/api_pb.jl
+++ b/src/google/api_pb.jl
@@ -10,12 +10,14 @@ mutable struct Method <: ProtoType
     response_streaming::Bool
     options::Base.Vector{Option}
     syntax::Int32
+    __fill_cache::Union{Nothing,BitArray{2}}
     Method(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct Method
 
 mutable struct Mixin <: ProtoType
     name::AbstractString
     root::AbstractString
+    __fill_cache::Union{Nothing,BitArray{2}}
     Mixin(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct Mixin
 
@@ -27,6 +29,7 @@ mutable struct Api <: ProtoType
     source_context::SourceContext
     mixins::Base.Vector{Mixin}
     syntax::Int32
+    __fill_cache::Union{Nothing,BitArray{2}}
     Api(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct Api
 

--- a/src/google/descriptor_pb.jl
+++ b/src/google/descriptor_pb.jl
@@ -203,6 +203,7 @@ mutable struct FieldDescriptorProto <: ProtoType
     oneof_index::Int32
     json_name::AbstractString
     options::FieldOptions
+    __fill_cache::Union{Nothing,BitArray{2}}
     FieldDescriptorProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct FieldDescriptorProto
 const __fnum_FieldDescriptorProto = Int[1,3,4,5,6,2,7,9,10,8]
@@ -212,6 +213,7 @@ mutable struct DescriptorProto_ExtensionRange <: ProtoType
     start::Int32
     _end::Int32
     options::ExtensionRangeOptions
+    __fill_cache::Union{Nothing,BitArray{2}}
     DescriptorProto_ExtensionRange(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct DescriptorProto_ExtensionRange
 
@@ -222,6 +224,7 @@ mutable struct MethodDescriptorProto <: ProtoType
     options::MethodOptions
     client_streaming::Bool
     server_streaming::Bool
+    __fill_cache::Union{Nothing,BitArray{2}}
     MethodDescriptorProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct MethodDescriptorProto
 const __val_MethodDescriptorProto = Dict(:client_streaming => false, :server_streaming => false)
@@ -231,12 +234,14 @@ mutable struct EnumValueDescriptorProto <: ProtoType
     name::AbstractString
     number::Int32
     options::EnumValueOptions
+    __fill_cache::Union{Nothing,BitArray{2}}
     EnumValueDescriptorProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct EnumValueDescriptorProto
 
 mutable struct EnumDescriptorProto_EnumReservedRange <: ProtoType
     start::Int32
     _end::Int32
+    __fill_cache::Union{Nothing,BitArray{2}}
     EnumDescriptorProto_EnumReservedRange(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct EnumDescriptorProto_EnumReservedRange
 
@@ -246,18 +251,21 @@ mutable struct EnumDescriptorProto <: ProtoType
     options::EnumOptions
     reserved_range::Base.Vector{EnumDescriptorProto_EnumReservedRange}
     reserved_name::Base.Vector{AbstractString}
+    __fill_cache::Union{Nothing,BitArray{2}}
     EnumDescriptorProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct EnumDescriptorProto
 
 mutable struct OneofDescriptorProto <: ProtoType
     name::AbstractString
     options::OneofOptions
+    __fill_cache::Union{Nothing,BitArray{2}}
     OneofDescriptorProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct OneofDescriptorProto
 
 mutable struct DescriptorProto_ReservedRange <: ProtoType
     start::Int32
     _end::Int32
+    __fill_cache::Union{Nothing,BitArray{2}}
     DescriptorProto_ReservedRange(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct DescriptorProto_ReservedRange
 
@@ -272,6 +280,7 @@ mutable struct DescriptorProto <: ProtoType
     options::MessageOptions
     reserved_range::Base.Vector{DescriptorProto_ReservedRange}
     reserved_name::Base.Vector{AbstractString}
+    __fill_cache::Union{Nothing,BitArray{2}}
     DescriptorProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct DescriptorProto
 const __fnum_DescriptorProto = Int[1,2,6,3,4,5,8,7,9,10]
@@ -281,6 +290,7 @@ mutable struct ServiceDescriptorProto <: ProtoType
     name::AbstractString
     method::Base.Vector{MethodDescriptorProto}
     options::ServiceOptions
+    __fill_cache::Union{Nothing,BitArray{2}}
     ServiceDescriptorProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct ServiceDescriptorProto
 
@@ -290,6 +300,7 @@ mutable struct SourceCodeInfo_Location <: ProtoType
     leading_comments::AbstractString
     trailing_comments::AbstractString
     leading_detached_comments::Base.Vector{AbstractString}
+    __fill_cache::Union{Nothing,BitArray{2}}
     SourceCodeInfo_Location(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct SourceCodeInfo_Location
 const __fnum_SourceCodeInfo_Location = Int[1,2,3,4,6]
@@ -298,6 +309,7 @@ meta(t::Type{SourceCodeInfo_Location}) = meta(t, ProtoBuf.DEF_REQ, __fnum_Source
 
 mutable struct SourceCodeInfo <: ProtoType
     location::Base.Vector{SourceCodeInfo_Location}
+    __fill_cache::Union{Nothing,BitArray{2}}
     SourceCodeInfo(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct SourceCodeInfo
 
@@ -314,6 +326,7 @@ mutable struct FileDescriptorProto <: ProtoType
     options::FileOptions
     source_code_info::SourceCodeInfo
     syntax::AbstractString
+    __fill_cache::Union{Nothing,BitArray{2}}
     FileDescriptorProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct FileDescriptorProto
 const __fnum_FileDescriptorProto = Int[1,2,3,10,11,4,5,6,7,8,9,12]
@@ -321,6 +334,7 @@ meta(t::Type{FileDescriptorProto}) = meta(t, ProtoBuf.DEF_REQ, __fnum_FileDescri
 
 mutable struct FileDescriptorSet <: ProtoType
     file::Base.Vector{FileDescriptorProto}
+    __fill_cache::Union{Nothing,BitArray{2}}
     FileDescriptorSet(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct FileDescriptorSet
 
@@ -329,6 +343,7 @@ mutable struct GeneratedCodeInfo_Annotation <: ProtoType
     source_file::AbstractString
     _begin::Int32
     _end::Int32
+    __fill_cache::Union{Nothing,BitArray{2}}
     GeneratedCodeInfo_Annotation(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct GeneratedCodeInfo_Annotation
 const __pack_GeneratedCodeInfo_Annotation = Symbol[:path]
@@ -336,6 +351,7 @@ meta(t::Type{GeneratedCodeInfo_Annotation}) = meta(t, ProtoBuf.DEF_REQ, ProtoBuf
 
 mutable struct GeneratedCodeInfo <: ProtoType
     annotation::Base.Vector{GeneratedCodeInfo_Annotation}
+    __fill_cache::Union{Nothing,BitArray{2}}
     GeneratedCodeInfo(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct GeneratedCodeInfo
 

--- a/src/google/duration_pb.jl
+++ b/src/google/duration_pb.jl
@@ -5,6 +5,7 @@ import ProtoBuf.meta
 mutable struct Duration <: ProtoType
     seconds::Int64
     nanos::Int32
+    __fill_cache::Union{Nothing,BitArray{2}}
     Duration(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct Duration
 

--- a/src/google/empty_pb.jl
+++ b/src/google/empty_pb.jl
@@ -3,6 +3,7 @@ using ProtoBuf
 import ProtoBuf.meta
 
 mutable struct Empty <: ProtoType
+    __fill_cache::Union{Nothing,BitArray{2}}
     Empty(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct Empty
 

--- a/src/google/field_mask_pb.jl
+++ b/src/google/field_mask_pb.jl
@@ -4,6 +4,7 @@ import ProtoBuf.meta
 
 mutable struct FieldMask <: ProtoType
     paths::Base.Vector{AbstractString}
+    __fill_cache::Union{Nothing,BitArray{2}}
     FieldMask(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct FieldMask
 

--- a/src/google/plugin_pb.jl
+++ b/src/google/plugin_pb.jl
@@ -7,6 +7,7 @@ mutable struct Version <: ProtoType
     minor::Int32
     patch::Int32
     suffix::AbstractString
+    __fill_cache::Union{Nothing,BitArray{2}}
     Version(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct Version
 
@@ -15,6 +16,7 @@ mutable struct CodeGeneratorRequest <: ProtoType
     parameter::AbstractString
     proto_file::Base.Vector{ProtoBuf.GoogleProtoBuf.FileDescriptorProto}
     compiler_version::Version
+    __fill_cache::Union{Nothing,BitArray{2}}
     CodeGeneratorRequest(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct CodeGeneratorRequest
 const __fnum_CodeGeneratorRequest = Int[1,2,15,3]
@@ -24,6 +26,7 @@ mutable struct CodeGeneratorResponse_File <: ProtoType
     name::AbstractString
     insertion_point::AbstractString
     content::AbstractString
+    __fill_cache::Union{Nothing,BitArray{2}}
     CodeGeneratorResponse_File(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct CodeGeneratorResponse_File
 const __fnum_CodeGeneratorResponse_File = Int[1,2,15]
@@ -32,6 +35,7 @@ meta(t::Type{CodeGeneratorResponse_File}) = meta(t, ProtoBuf.DEF_REQ, __fnum_Cod
 mutable struct CodeGeneratorResponse <: ProtoType
     error::AbstractString
     file::Base.Vector{CodeGeneratorResponse_File}
+    __fill_cache::Union{Nothing,BitArray{2}}
     CodeGeneratorResponse(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct CodeGeneratorResponse
 const __fnum_CodeGeneratorResponse = Int[1,15]

--- a/src/google/source_context_pb.jl
+++ b/src/google/source_context_pb.jl
@@ -4,6 +4,7 @@ import ProtoBuf.meta
 
 mutable struct SourceContext <: ProtoType
     file_name::AbstractString
+    __fill_cache::Union{Nothing,BitArray{2}}
     SourceContext(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct SourceContext
 

--- a/src/google/struct_pb.jl
+++ b/src/google/struct_pb.jl
@@ -11,6 +11,7 @@ const NullValue = __enum_NullValue()
 mutable struct Struct_FieldsEntry <: ProtoType
     key::AbstractString
     value::Base.Any
+    __fill_cache::Union{Nothing,BitArray{2}}
     Struct_FieldsEntry(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct Struct_FieldsEntry (mapentry) (has cyclic type dependency)
 const __ftype_Struct_FieldsEntry = Dict(:value => "Value")
@@ -18,6 +19,7 @@ meta(t::Type{Struct_FieldsEntry}) = meta(t, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM,
 
 mutable struct Struct <: ProtoType
     fields::Base.Dict # map entry
+    __fill_cache::Union{Nothing,BitArray{2}}
     Struct(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct Struct (has cyclic type dependency)
 const __ftype_Struct = Dict(:fields => "Base.Dict{AbstractString,Value}")
@@ -30,6 +32,7 @@ mutable struct Value <: ProtoType
     bool_value::Bool
     struct_value::Struct
     list_value::Base.Any
+    __fill_cache::Union{Nothing,BitArray{2}}
     Value(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct Value (has cyclic type dependency)
 const __ftype_Value = Dict(:list_value => "ListValue")
@@ -39,6 +42,7 @@ meta(t::Type{Value}) = meta(t, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF
 
 mutable struct ListValue <: ProtoType
     values::Base.Vector{Value}
+    __fill_cache::Union{Nothing,BitArray{2}}
     ListValue(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct ListValue (has cyclic type dependency)
 

--- a/src/google/timestamp_pb.jl
+++ b/src/google/timestamp_pb.jl
@@ -5,6 +5,7 @@ import ProtoBuf.meta
 mutable struct Timestamp <: ProtoType
     seconds::Int64
     nanos::Int32
+    __fill_cache::Union{Nothing,BitArray{2}}
     Timestamp(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct Timestamp
 

--- a/src/google/type_pb.jl
+++ b/src/google/type_pb.jl
@@ -12,6 +12,7 @@ const Syntax = __enum_Syntax()
 mutable struct Option <: ProtoType
     name::AbstractString
     value::_Any
+    __fill_cache::Union{Nothing,BitArray{2}}
     Option(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct Option
 
@@ -19,6 +20,7 @@ mutable struct EnumValue <: ProtoType
     name::AbstractString
     number::Int32
     options::Base.Vector{Option}
+    __fill_cache::Union{Nothing,BitArray{2}}
     EnumValue(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct EnumValue
 
@@ -66,6 +68,7 @@ mutable struct Field <: ProtoType
     options::Base.Vector{Option}
     json_name::AbstractString
     default_value::AbstractString
+    __fill_cache::Union{Nothing,BitArray{2}}
     Field(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct Field
 const __fnum_Field = Int[1,2,3,4,6,7,8,9,10,11]
@@ -77,6 +80,7 @@ mutable struct _Enum <: ProtoType
     options::Base.Vector{Option}
     source_context::SourceContext
     syntax::Int32
+    __fill_cache::Union{Nothing,BitArray{2}}
     _Enum(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct _Enum
 
@@ -87,6 +91,7 @@ mutable struct _Type <: ProtoType
     options::Base.Vector{Option}
     source_context::SourceContext
     syntax::Int32
+    __fill_cache::Union{Nothing,BitArray{2}}
     _Type(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct _Type
 

--- a/src/google/wrappers_pb.jl
+++ b/src/google/wrappers_pb.jl
@@ -4,46 +4,55 @@ import ProtoBuf.meta
 
 mutable struct DoubleValue <: ProtoType
     value::Float64
+    __fill_cache::Union{Nothing,BitArray{2}}
     DoubleValue(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct DoubleValue
 
 mutable struct FloatValue <: ProtoType
     value::Float32
+    __fill_cache::Union{Nothing,BitArray{2}}
     FloatValue(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct FloatValue
 
 mutable struct Int64Value <: ProtoType
     value::Int64
+    __fill_cache::Union{Nothing,BitArray{2}}
     Int64Value(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct Int64Value
 
 mutable struct UInt64Value <: ProtoType
     value::UInt64
+    __fill_cache::Union{Nothing,BitArray{2}}
     UInt64Value(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct UInt64Value
 
 mutable struct Int32Value <: ProtoType
     value::Int32
+    __fill_cache::Union{Nothing,BitArray{2}}
     Int32Value(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct Int32Value
 
 mutable struct UInt32Value <: ProtoType
     value::UInt32
+    __fill_cache::Union{Nothing,BitArray{2}}
     UInt32Value(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct UInt32Value
 
 mutable struct BoolValue <: ProtoType
     value::Bool
+    __fill_cache::Union{Nothing,BitArray{2}}
     BoolValue(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct BoolValue
 
 mutable struct StringValue <: ProtoType
     value::AbstractString
+    __fill_cache::Union{Nothing,BitArray{2}}
     StringValue(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct StringValue
 
 mutable struct BytesValue <: ProtoType
     value::Array{UInt8,1}
+    __fill_cache::Union{Nothing,BitArray{2}}
     BytesValue(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct BytesValue
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -2,7 +2,16 @@
 
 isinitialized(obj::Any) = isfilled(obj)
 
-setproperty!(obj::ProtoType, fld::Symbol, val) = (Core.setfield!(obj, fld, val); fillset(obj, fld); val)
+function setproperty!(obj::ProtoType, fld::Symbol, val)
+    if fld == :__fill_cache
+        # done by `filled`... shouldn't be done by user code...
+        Core.setfield!(obj, fld, val)
+        return
+    end
+    Core.setfield!(obj, fld, val)
+    fillset(obj, fld)
+    val
+end
 @deprecate set_field!(obj::Any, fld::Symbol, val) setproperty!(obj, fld, val)
 
 get_field(obj::Any, fld::Symbol) = isfilled(obj, fld) ? getfield(obj, fld) : error("uninitialized field $fld")

--- a/test/services/testsvc.jl
+++ b/test/services/testsvc.jl
@@ -25,6 +25,8 @@ close(channel::TestRpcChannel) = close(channel.sock)
 
 mutable struct SvcHeader <: ProtoType
     method::String
+    __fill_cache::Union{Nothing,BitArray{2}}
+
     SvcHeader() = (o=new(); fillunset(o); o)
 end
 
@@ -90,7 +92,7 @@ function call_method(channel::TestRpcChannel, service::ServiceDescriptor, method
 end
 
 # Test server implementation on the RpcChannel
-# 
+#
 mutable struct TestServer
     srvr::TCPServer
     impl::ProtoService
@@ -181,7 +183,7 @@ function run_client(debug::Bool)
         inp = BinaryOpReq()
         inp.i1 = Int64(rand(Int8))
         inp.i2 = Int64(rand(Int8))
-       
+
         nresults -= 1
         let channel=TestRpcChannel(connect(9999)), stub=TestMathStub(channel), expected=inp.i1+inp.i2
             Add(stub, controller, inp, (out)->chk_results(out, expected, channel))

--- a/test/services/testsvc_pb.jl
+++ b/test/services/testsvc_pb.jl
@@ -6,6 +6,8 @@ import Base: hash, isequal, ==
 mutable struct BinaryOpReq <: ProtoType
     i1::Int64
     i2::Int64
+    __fill_cache::Union{Nothing,BitArray{2}}
+
     BinaryOpReq(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #type BinaryOpReq
 hash(v::BinaryOpReq) = ProtoBuf.protohash(v)
@@ -14,6 +16,8 @@ isequal(v1::BinaryOpReq, v2::BinaryOpReq) = ProtoBuf.protoisequal(v1, v2)
 
 mutable struct BinaryOpResp <: ProtoType
     result::Int64
+    __fill_cache::Union{Nothing,BitArray{2}}
+
     BinaryOpResp(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #type BinaryOpResp
 hash(v::BinaryOpResp) = ProtoBuf.protohash(v)
@@ -31,11 +35,15 @@ TestMath(impl::Module) = ProtoService(_TestMath_desc, impl)
 
 mutable struct TestMathStub <: AbstractProtoServiceStub{false}
     impl::ProtoServiceStub
+    __fill_cache::Union{Nothing,BitArray{2}}
+
     TestMathStub(channel::ProtoRpcChannel) = new(ProtoServiceStub(_TestMath_desc, channel))
 end # type TestMathStub
 
 mutable struct TestMathBlockingStub <: AbstractProtoServiceStub{true}
     impl::ProtoServiceBlockingStub
+    __fill_cache::Union{Nothing,BitArray{2}}
+
     TestMathBlockingStub(channel::ProtoRpcChannel) = new(ProtoServiceBlockingStub(_TestMath_desc, channel))
 end # type TestMathBlockingStub
 

--- a/test/testcodec.jl
+++ b/test/testcodec.jl
@@ -16,10 +16,16 @@ print_hdr(tname) = println("testing $tname...")
 
 mutable struct TestType <: ProtoType
     val::Any
+    __fill_cache::Union{Nothing,BitArray{2}}
+
+    TestType(val) = new(val, nothing)
 end
 
 mutable struct TestStr <: ProtoType
     val::AbstractString
+    __fill_cache::Union{Nothing,BitArray{2}}
+
+    TestStr(val) = new(val, nothing)
 end
 ==(t1::TestStr, t2::TestStr) = (t1.val == t2.val)
 
@@ -27,20 +33,27 @@ mutable struct TestOptional <: ProtoType
     sVal1::TestStr
     sVal2::TestStr
     iVal2::Array{Int64,1}
+    __fill_cache::Union{Nothing,BitArray{2}}
+
+    TestOptional(sVal1, sVal2, iVal2) = new(sVal1, sVal2, iVal2, nothing)
 end
 
 mutable struct TestNested <: ProtoType
     fld1::TestType
     fld2::TestOptional
     fld3::Array{TestStr}
+    __fill_cache::Union{Nothing,BitArray{2}}
+
+    TestNested(fld1, fld2, fld3) = new(fld1, fld2, fld3, nothing)
 end
 
 mutable struct TestDefaults <: ProtoType
     iVal1::Int64
     sVal2::AbstractString
     iVal2::Array{Int64,1}
+    __fill_cache::Union{Nothing,BitArray{2}}
 
-    TestDefaults(f1,f2,f3) = new(f1,f2,f3)
+    TestDefaults(f1,f2,f3) = new(f1, f2, f3, nothing)
     TestDefaults() = new()
 end
 
@@ -48,6 +61,7 @@ mutable struct TestOneofs <: ProtoType
     iVal1::Int64
     iVal2::Int64
     iVal3::Int64
+    __fill_cache::Union{Nothing,BitArray{2}}
 
     TestOneofs() = new()
 end
@@ -56,12 +70,16 @@ mutable struct TestMaps <: ProtoType
     d1::Dict{Int,Int}
     d2::Dict{Int32,String}
     d3::Dict{String,String}
+    __fill_cache::Union{Nothing,BitArray{2}}
+
     TestMaps() = new()
 end
 
 mutable struct TestFilled <: ProtoType
     fld1::TestType
     fld2::TestType
+    __fill_cache::Union{Nothing,BitArray{2}}
+
     TestFilled() = new()
 end
 
@@ -129,9 +147,9 @@ function assert_equal(val1, val2)
     typ1 = typeof(val1)
     typ2 = typeof(val2)
     assert_equal(typ1, typ2)
-   
-    n = fieldnames(typ1)
-    t = typ1.types 
+
+    n = [name for name in fieldnames(typ1) if name != :__fill_cache]
+    t = typ1.types
     for fld in n
         fldfill1 = isfilled(val1, fld)
         fldfill2 = isfilled(val2, fld)
@@ -212,7 +230,7 @@ function test_types()
                 testval.val = convert(typ, @_rand_int(UInt32, 10^9, 0))
                 fldnum = @_rand_int(Int, 100, 1)
                 meta = mk_test_meta(fldnum, ptyp)
-                writeproto(pb, testval, meta) 
+                writeproto(pb, testval, meta)
                 readproto(pb, readval, meta)
                 assert_equal(testval, readval)
             end
@@ -224,7 +242,7 @@ function test_types()
         testval.val = randstring(50)
         fldnum = @_rand_int(Int, 100, 1)
         meta = mk_test_meta(fldnum, :string)
-        writeproto(pb, testval, meta) 
+        writeproto(pb, testval, meta)
         readproto(pb, readval, meta)
         assert_equal(testval, readval)
     end
@@ -242,7 +260,7 @@ function test_repeats()
         fldnum = @_rand_int(Int, 100, 1)
         meta = mk_test_meta(fldnum, :int64)
         meta.ordered[1].occurrence = 2
-        writeproto(pb, testval, meta) 
+        writeproto(pb, testval, meta)
         readproto(pb, readval, meta)
         assert_equal(testval, readval)
     end
@@ -255,19 +273,19 @@ function test_repeats()
         meta = mk_test_meta(fldnum, :int64)
         meta.ordered[1].occurrence = 2
         meta.ordered[1].packed = true
-        writeproto(pb, testval, meta) 
+        writeproto(pb, testval, meta)
         readproto(pb, readval, meta)
         assert_equal(testval, readval)
     end
 
     print_hdr("repeated string")
     for idx in 1:100
-        testval.val = [randstring(5) for i in 1:10] 
+        testval.val = [randstring(5) for i in 1:10]
         readval.val = AbstractString[]
         fldnum = @_rand_int(Int, 100, 1)
         meta = mk_test_meta(fldnum, :string)
         meta.ordered[1].occurrence = 2
-        writeproto(pb, testval, meta) 
+        writeproto(pb, testval, meta)
         readproto(pb, readval, meta)
         assert_equal(testval, readval)
     end

--- a/test/testcodec.jl
+++ b/test/testcodec.jl
@@ -26,6 +26,7 @@ mutable struct TestStr <: ProtoType
     __fill_cache::Union{Nothing,BitArray{2}}
 
     TestStr(val) = new(val, nothing)
+    TestStr() = new()
 end
 ==(t1::TestStr, t2::TestStr) = (t1.val == t2.val)
 
@@ -353,6 +354,7 @@ function test_nested()
         writeproto(pb, testval, meta)
         readfld2.iVal2 = Int64[]
         readval.fld3 = TestStr[]
+        println("readproto pb=$pb readval=$readval meta=$meta")
         readproto(pb, readval, meta)
 
         assert_equal(testval, readval)
@@ -517,5 +519,3 @@ ProtoBufTestCodec.test_misc()
 GC.gc()
 println("_metacache has $(length(ProtoBuf._metacache)) entries")
 #println(ProtoBuf._metacache)
-println("_fillcache has $(length(ProtoBuf._fillcache)) entries")
-#println(ProtoBuf._fillcache)

--- a/test/testtypevers.jl
+++ b/test/testtypevers.jl
@@ -5,16 +5,18 @@ print_hdr(tname) = println("testing $tname...")
 mutable struct V1
     f1::Int32
     f2::Bool
+    __fill_cache::Union{Nothing,BitArray{2}}
     V1() = (a=new(); clear(a); a)
-    V1(f1,f2) = new(f1,f2)
+    V1(f1,f2) = new(f1,f2,nothing)
 end
 
 mutable struct V2
     f1::Int64
     f2::Bool
     f3::Int64
+    __fill_cache::Union{Nothing,BitArray{2}}
     V2() = (a=new(); clear(a); a)
-    V2(f1,f2,f3) = new(f1,f2,f3)
+    V2(f1,f2,f3) = new(f1,f2,f3,nothing)
 end
 
 function check_samestruct()

--- a/test/testutilapi.jl
+++ b/test/testutilapi.jl
@@ -8,6 +8,8 @@ print_hdr(tname) = println("testing $tname...")
 mutable struct TestType <: ProtoType
     a::AbstractString
     b::Bool
+    __fill_cache::Union{Nothing,BitArray{2}}
+
     TestType() = (o=new(); fillunset(o); o)
 end #type TestType
 meta(t::Type{TestType}) = meta(t, Symbol[:a], Int[], Dict{Symbol,Any}())


### PR DESCRIPTION
Instead of using a global dictionary to store field status for all objects, put a field on each object, leaving most of the logic in tact but getting rid of thread safety issues.